### PR TITLE
Changed setting extended info to separate upserts

### DIFF
--- a/ClassifyData/ClassifyData.csproj
+++ b/ClassifyData/ClassifyData.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Service\ConfigurationActions.cs" />
     <Compile Include="Service\Database.cs" />
     <Compile Include="Service\DatabaseActions.cs" />
+    <Compile Include="Service\DataBaseExtensions.cs" />
     <Compile Include="Service\PersistentObjectActionsReference.cs" />
     <Content Include="App_Data\Websites\Default\index.html">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/ClassifyData/Service/DataBaseExtensions.cs
+++ b/ClassifyData/Service/DataBaseExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System.Data;
+
+namespace ClassifyData.Service
+{
+	internal static class DataBaseExtensions {
+		public static void AddParameterWithValue(this IDbCommand cmd, string name, object value)
+		{
+			var p = cmd.CreateParameter();
+			p.ParameterName = name;
+			p.Value = value;
+			cmd.Parameters.Add(p);
+		}
+	}
+}


### PR DESCRIPTION
This allows other extended properties to be set independently without  'InformationTypeId' having been specified
Made `tablesFormat` and `columnsFormat ` more readable
Ensured join is on column  information so that sensitivity label can be obtained independently from information type.

My intention is to extend the classification of columns so other aspects of GDPR decision can be stored here too.